### PR TITLE
docs: make browser quickstart non-destructive

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ await init();
 // Connect to YubiKey (requires user gesture)
 const device = await YubiKeyDevice.connect();
 
-// Generate a new key
-const address = await device.generateKey("123456");
+// Use an existing key's address (safe default)
+const address = await device.getAddress();
 
-// Sign a transaction
-const signature = await device.signTransaction("123456", JSON.stringify({
+// Sign a transaction (prompt user for PIN; avoid hardcoding secrets)
+const pin = "<PIN_FROM_USER_INPUT>";
+const signature = await device.signTransaction(pin, JSON.stringify({
     type: "eip1559",
     chain_id: 1,
     nonce: 0,
@@ -79,6 +80,10 @@ const signature = await device.signTransaction("123456", JSON.stringify({
 
 await device.disconnect();
 ```
+
+
+> **Warning**: `generateKey(pin)` is destructive and overwrites any existing private key in the selected PIV slot (default slot 9a).
+> Only call it when you intentionally want to replace that key, and back up account access before doing so.
 
 > **Note**: WebUSB is only supported in Chromium-based browsers (Chrome, Edge, Opera, Brave) and requires HTTPS.
 > WebUSB does **not** work on macOS due to kernel driver conflicts. Use the native CLI instead.


### PR DESCRIPTION
### Motivation
- Fix a documentation-induced security risk where the README browser quick start recommended `generateKey("123456")` (a destructive PIV operation that can overwrite a non-exportable private key in slot 9a) without warning.

### Description
- Update `README.md` browser example to use `getAddress()` instead of `generateKey(...)`, replace the hardcoded PIN with a `"<PIN_FROM_USER_INPUT>"` placeholder, and add an explicit warning that `generateKey(pin)` overwrites any existing private key in the default PIV slot (9a).

### Testing
- Documentation-only change; verified updated content and diffs by running `rg` to list files, inspected `README.md` with `sed`/`nl`, reviewed the `git diff`, and committed the change, with all checks passing (no crate tests required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7441feeac8330a4dc641dc5f20b76)