### PR TITLE
fix(wasm): harden parsing of untrusted WebUSB responses

### DIFF
--- a/crates/signer-wasm/src/device.rs
+++ b/crates/signer-wasm/src/device.rs
@@ -485,44 +485,25 @@ fn parse_public_key_response(data: &[u8]) -> Option<VerifyingKey> {
     i += 2;
 
     // Skip length
-    if data[i] >= 0x80 {
-        i += 1 + (data[i] & 0x7F) as usize;
-    } else {
-        i += 1;
-    }
+    let (_, consumed) = parse_der_length(data, i)?;
+    i = i.checked_add(consumed)?;
 
     // Find tag 86
     while i < data.len() {
         if data[i] == 0x86 {
             i += 1;
-            let len = if data[i] >= 0x80 {
-                let len_bytes = (data[i] & 0x7F) as usize;
-                i += 1;
-                let mut len = 0usize;
-                for j in 0..len_bytes {
-                    len = (len << 8) | (data[i + j] as usize);
-                }
-                i += len_bytes;
-                len
-            } else {
-                let len = data[i] as usize;
-                i += 1;
-                len
-            };
+            let (len, consumed) = parse_der_length(data, i)?;
+            i = i.checked_add(consumed)?;
+            let end = i.checked_add(len)?;
 
-            if len == 65 && data[i] == 0x04 {
-                let point_bytes = &data[i..i + len];
+            if len == 65 && data.get(i) == Some(&0x04) && end <= data.len() {
+                let point_bytes = &data[i..end];
                 let point = EncodedPoint::from_bytes(point_bytes).ok()?;
                 return VerifyingKey::from_encoded_point(&point).ok();
             }
             break;
         }
         i += 1;
-        if i >= data.len() {
-            break;
-        }
-        let len = data[i] as usize;
-        i += 1 + len;
     }
 
     None
@@ -558,11 +539,8 @@ fn parse_signature_response(data: &[u8]) -> Option<Vec<u8>> {
     if i >= data.len() {
         return None;
     }
-    if data[i] >= 0x80 {
-        i += 1 + (data[i] & 0x7F) as usize;
-    } else {
-        i += 1;
-    }
+    let (_, consumed) = parse_der_length(data, i)?;
+    i = i.checked_add(consumed)?;
 
     // Find tag 82
     while i < data.len() {
@@ -572,26 +550,12 @@ fn parse_signature_response(data: &[u8]) -> Option<Vec<u8>> {
                 return None;
             }
 
-            let len = if data[i] >= 0x80 {
-                let len_bytes = (data[i] & 0x7F) as usize;
-                i += 1;
-                let mut len = 0usize;
-                for j in 0..len_bytes {
-                    if i + j >= data.len() {
-                        return None;
-                    }
-                    len = (len << 8) | (data[i + j] as usize);
-                }
-                i += len_bytes;
-                len
-            } else {
-                let len = data[i] as usize;
-                i += 1;
-                len
-            };
+            let (len, consumed) = parse_der_length(data, i)?;
+            i = i.checked_add(consumed)?;
+            let end = i.checked_add(len)?;
 
-            if i + len <= data.len() {
-                return Some(data[i..i + len].to_vec());
+            if end <= data.len() {
+                return Some(data[i..end].to_vec());
             }
             break;
         }
@@ -599,6 +563,30 @@ fn parse_signature_response(data: &[u8]) -> Option<Vec<u8>> {
     }
 
     None
+}
+
+/// Parses a DER-style length at `offset` and returns `(value, consumed_bytes)`.
+fn parse_der_length(data: &[u8], offset: usize) -> Option<(usize, usize)> {
+    let first = *data.get(offset)?;
+    if first < 0x80 {
+        return Some((first as usize, 1));
+    }
+
+    let len_bytes = (first & 0x7F) as usize;
+    if len_bytes == 0 {
+        return None;
+    }
+
+    let start = offset.checked_add(1)?;
+    let end = start.checked_add(len_bytes)?;
+    let bytes = data.get(start..end)?;
+
+    let mut len = 0usize;
+    for &b in bytes {
+        len = len.checked_shl(8)? | usize::from(b);
+    }
+
+    Some((len, 1 + len_bytes))
 }
 
 #[cfg(test)]

--- a/crates/signer-wasm/src/transport.rs
+++ b/crates/signer-wasm/src/transport.rs
@@ -306,11 +306,15 @@ impl WebUsbTransport {
         // Extract data length
         let data_len = u32::from_le_bytes([ccid[1], ccid[2], ccid[3], ccid[4]]) as usize;
 
-        if ccid.len() < 10 + data_len {
+        let end = 10usize
+            .checked_add(data_len)
+            .ok_or_else(|| WasmError::UsbError("CCID data length overflow".to_string()))?;
+
+        if ccid.len() < end {
             return Err(WasmError::UsbError("CCID data length mismatch".to_string()));
         }
 
-        Ok(ccid[10..10 + data_len].to_vec())
+        Ok(ccid[10..end].to_vec())
     }
 
     /// Transmits an APDU and receives the response (async version).


### PR DESCRIPTION
### Motivation
- The WASM WebUSB transport parsed CCID/APDU/TLV lengths from device-controlled bytes with unchecked indexing and additions, which can panic on malformed or malicious USB responses and produce a denial-of-service in the browser signer.
- The change aims to close those panic/overflow attack surfaces while preserving existing behavior for well-formed responses.

### Description
- Added a safe length decoder `parse_der_length(data, offset)` that validates bounds and prevents integer-overflow when decoding DER/TLV lengths in `crates/signer-wasm/src/device.rs`.
- Rewrote `parse_public_key_response` to use `parse_der_length`, to advance offsets using `checked_add`, and to validate slice bounds before indexing or slicing the public key bytes.
- Rewrote `parse_signature_response` to use `parse_der_length`, to validate computed end offsets with `checked_add`, and to avoid any unchecked `data[i + ...]` or slicing beyond `data.len()`.
- Hardened `unwrap_ccid` in `crates/signer-wasm/src/transport.rs` by computing `end = 10.checked_add(data_len)` with overflow checking and using `end` for the final slice, preventing `10 + data_len` overflow on `wasm32`.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p yubikey-evm-signer-wasm --lib`, which compiled the crate and executed unit tests; all tests passed (4 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f75660c5dc83308d6f7af0230af4aa)